### PR TITLE
Read meteo on start, add debug for no own position

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,8 @@ module.exports = function createPlugin(app) {
             })
           })
       })
+    } else {
+      debug("No own position, can not fetch nearest stations' data");
     }
   };
   return plugin;

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = function createPlugin(app) {
   const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
   let numberOfStations
   let updateWeather
-  let distToStation = []
   let interval
   let intervalTime = 10000
 
@@ -46,7 +45,6 @@ module.exports = function createPlugin(app) {
 
   plugin.stop = function stop() {
     clearInterval(interval);
-    distToStation = []
     app.debug('Signal K Net Weather Finland stopped');
   };
 
@@ -154,7 +152,7 @@ module.exports = function createPlugin(app) {
       if (intervalTime !== updateWeather * 60000) {
         clear();
       }
-      distToStation = []
+      let distToStation = []
       const ownLocation = { latitude: ownLat, longitude: ownLon }
       stations.forEach(([longName, shortName, fmisid, lat, lon]) => {
         const distance = haversine(ownLocation, { latitude: lat, longitude: lon })

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function createPlugin(app) {
     updateWeather = options.updateWeather
     numberOfStations = options.numberOfStations
     interval = setInterval(readMeteo, (intervalTime));
+    readMeteo();
   };
 
   plugin.stop = function stop() {


### PR DESCRIPTION
Fetch data on plugin start: The normal, pretty long intervals make the user wait a little
long after install / server restart to see any data and if the plugin is working at all. This changes the logic so that data is fetched when the plugin starts.

Also adds debug message for situation where there is no own data and nothing is fetched and a small refactor.